### PR TITLE
add creator to metadata, enable dictionary update for metadata, raise status for failign request

### DIFF
--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -185,7 +185,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_depositions_by_id(self, dep_id=None):
         """gets the deposition based on project id
@@ -206,7 +206,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_depositions_files(self):
         """gets the file deposition
@@ -223,7 +223,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_bucket_by_title(self, title=None):
         """gets the bucket URL by project title
@@ -246,7 +246,7 @@ class Client(object):
         if r.ok:
             return r.json()['links']['bucket']
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_bucket_by_id(self, dep_id=None):
         """gets the bucket URL by project deposition ID
@@ -266,7 +266,7 @@ class Client(object):
         if r.ok:
             return r.json()['links']['bucket']
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_api(self):
         # get request, returns our response
@@ -275,7 +275,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     # ---------------------------------------------
     # user facing functions/properties
@@ -451,7 +451,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def upload_file(self, file_path=None, publish=False):
         """upload a file to a project

--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -410,6 +410,7 @@ class Client(object):
                         title=None,
                         upload_type=None,
                         description=None,
+                        **kwargs
                         ):
         """change projects metadata
 
@@ -425,6 +426,7 @@ class Client(object):
             title (str): new title of project
             upload_type (str): new upload type
             description (str): new description
+            **kwargs: dictionary to update default metadata
 
         Returns:
             dict: dictionary with new metadata
@@ -442,6 +444,8 @@ class Client(object):
                 "description": f"{description}",
             }
         }
+        # update metadata with a new metadata dictionary
+        data.update(kwargs) 
 
         r = requests.put(f"{self._endpoint}/deposit/depositions/{dep_id}",
                          auth=self._bearer_auth,

--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -410,6 +410,7 @@ class Client(object):
                         title=None,
                         upload_type=None,
                         description=None,
+                        creator=None,
                         **kwargs
                         ):
         """change projects metadata
@@ -436,12 +437,16 @@ class Client(object):
 
         if description is None:
             description = "description goes here"
+        
+        if creator is None:
+            creator = "creator goes here"
 
         data = {
             "metadata": {
                 "title": f"{title}",
                 "upload_type": f"{upload_type}",
                 "description": f"{description}",
+                "creators": [{"name": f"{creator}"}]
             }
         }
         # update metadata with a new metadata dictionary


### PR DESCRIPTION
This patch includes several minor fixes and additions:
- if the REST API request fails it is more informative to check the status `r.raise_for_status()` than `None`
- it is now possible to update the [metadata](https://developers.zenodo.org/#representation) in `change_metadata()` with a dictionary update which increases flexibility
- we also had to provide a default for the `creator=None` otherwhise no project could be published