### PR TITLE
Stacked PR. Add more information to zeno.list_projects

### DIFF
--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -185,7 +185,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_depositions_by_id(self, dep_id=None):
         """gets the deposition based on project id
@@ -206,7 +206,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_depositions_files(self):
         """gets the file deposition
@@ -223,7 +223,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_bucket_by_title(self, title=None):
         """gets the bucket URL by project title
@@ -246,7 +246,7 @@ class Client(object):
         if r.ok:
             return r.json()['links']['bucket']
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_bucket_by_id(self, dep_id=None):
         """gets the bucket URL by project deposition ID
@@ -266,7 +266,7 @@ class Client(object):
         if r.ok:
             return r.json()['links']['bucket']
         else:
-            return None
+            return r.raise_for_status()
 
     def _get_api(self):
         # get request, returns our response
@@ -275,7 +275,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     # ---------------------------------------------
     # user facing functions/properties
@@ -451,7 +451,7 @@ class Client(object):
         if r.ok:
             return r.json()
         else:
-            return None
+            return r.raise_for_status()
 
     def upload_file(self, file_path=None, publish=False):
         """upload a file to a project

--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -318,19 +318,22 @@ class Client(object):
         tmp = self._get_depositions()
 
         if isinstance(tmp, list):
-            print('Project Name ---- ID')
+            print('Project Name ---- ID ---- Status ---- Latest Published ID')
             print('------------------------')
             for file in tmp:
-                # dic[file['title']] = file['id']
-                print(f"{file['title']} ----- {file['id']}")
+                status = {}  # just to rename the file outputs and deal with exceptions
+                if file['submitted']:
+                    status['submitted'] = 'published'
+                else:
+                    status['submitted'] = 'unpublished'
+                try:
+                    status["latest"] = ''.join([c for c in file['links']['latest'] if c.isdigit()])
+                except:
+                    status["latest_draft"] = 'None'
+                    
+                print(f"{file['title']} ---- {file['id']} ---- {status['submitted']} ---- {status['latest_draft']}")
         else:
             print(' ** need to setup ~/.zenodo_token file ** ')
-
-        # print('Project Name ---- ID')
-        # print('------------------------')
-        # for key, val in dic.items():
-        #    print(f"{key} ---- {val}")
-        # return dic
 
     @property
     def list_files(self):

--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -410,6 +410,7 @@ class Client(object):
                         title=None,
                         upload_type=None,
                         description=None,
+                        **kwargs
                         ):
         """change projects metadata
 
@@ -425,6 +426,7 @@ class Client(object):
             title (str): new title of project
             upload_type (str): new upload type
             description (str): new description
+            **kwargs: dictionary to update default metadata
 
         Returns:
             dict: dictionary with new metadata
@@ -442,6 +444,8 @@ class Client(object):
                 "description": f"{description}",
             }
         }
+        # update metadata with a new metadata dictionary
+        data.update(kwargs) 
 
         r = requests.put(f"{self._endpoint}/deposit/depositions/{dep_id}",
                          auth=self._bearer_auth,

--- a/src/zenodopy/zenodopy.py
+++ b/src/zenodopy/zenodopy.py
@@ -410,6 +410,7 @@ class Client(object):
                         title=None,
                         upload_type=None,
                         description=None,
+                        creator=None,
                         **kwargs
                         ):
         """change projects metadata
@@ -436,12 +437,16 @@ class Client(object):
 
         if description is None:
             description = "description goes here"
+        
+        if creator is None:
+            creator = "creator goes here"
 
         data = {
             "metadata": {
                 "title": f"{title}",
                 "upload_type": f"{upload_type}",
                 "description": f"{description}",
+                "creators": [{"name": f"{creator}"}]
             }
         }
         # update metadata with a new metadata dictionary


### PR DESCRIPTION
Stacked PR on https://github.com/lgloege/zenodopy/pull/10

Running `zeno.list_projects` can be helpful to get a feeling which projects are registered and what ID to choose for e.g. `zeno.set_project(dep_id=<ID>)`. However, with the current information (title and ID) it is hard to judge if I pick the right project.

`zeno.update()` only works with a **published** repo. And running the update works only on the first run since `update` will create a new **ID** for the new edits, letting `set_project` project break. E.g. the below example will only work for the first run. For the second run, I have to manually find out the new ID and input it to `set_project` (well letting `zeno.set_project()` allow to read in also the `latest published ID`and then picking the new ID would be nice but is a matter of another PR).

```
zeno = zenopy.Client()
zeno.set_project(<ID>)
zeno.update(<file>)
zeno.list_projects
```

`zeno.upload` only works with unpublished project.

So adding `Status` and `Latest Published ID` might come handy and is proposed in this PR.

OLD:
![image](https://user-images.githubusercontent.com/61968949/231594654-8ad5aab6-e81e-4edc-b2d3-e5a28a93ea02.png)

NEW:
![image](https://user-images.githubusercontent.com/61968949/231594533-1733007e-045a-4dae-b5d0-873058d3d9d1.png)
