### PR TITLE
version update function fix

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "title": "my demo data",
+    "upload_type": "other",
+    "description": "",
+    "version": "0.9.4",
+    "access_right": "open",
+    "license": "Apache-2.0",
+    "keywords": ["zenodo", "github", "git"],
+    "publication_date":"",
+    "creators": [
+      {
+        "name": "Jhon, Doe",
+        "orcid": "0000-0003-2584-3576"
+      }
+    ]
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.26.0
 types-requests==2.27.7
 wget==3.2
+datetime

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     requests>=2
     types-requests>=2
     wget>=3
+    datetime
         
 python_requires = >=3.6
 package_dir =


### PR DESCRIPTION

- `set_project` can now also be update parent DOI 
  - it returns the latest draft or published version if given parent DOI 
     ![parent and version ID's](https://github.com/user-attachments/assets/a4b6a9db-882a-44fd-82ba-3f4ecf09bcc5)
  - function now gives automatically resolves to latest `113600` ID for `106299`

- updated `change_metadata` function adding metadata from `.json` file instead or python args 
- metadata can be extended to include these properties [Zenodo docs metadata](https://developers.zenodo.org/#representation)

- `update` function adds `publication_date` to metadata if empty which is required to publish a new version

